### PR TITLE
Edit HTF_skill to resolve error with certain input years

### DIFF
--- a/main code functions/HTF_skill.m
+++ b/main code functions/HTF_skill.m
@@ -42,12 +42,11 @@ skillOut.leadTime=NaN(366,240);
 % Need to skip the first time
 %step since we don't have observations the month before, so filling the
 %dateTime values for comparing with obs later
-%check if there is a leap year
-if mod(year(resOut.yrMoTime(1)),4) == 0 && (mod(year(resOut.yrMoTime(1)),100) ~= 0 || mod(year(resOut.yrMoTime(1)),400) == 0)
-    skillOut.dateTime(:,1)=resOut.yrMoTime(1):day(1):resOut.yrMoTime(1)+calmonths(12);
-else
-    skillOut.dateTime(:,1)=resOut.yrMoTime(1):day(1):resOut.yrMoTime(1)+calmonths(12)-day(1);
-end    
+yr1 = resOut.dateTime(year(resOut.dateTime)==year(resOut.dateTime(1)));
+[~,iu] = unique(datestr(yr1,'dd-mmm-yyyy'),'rows','stable');
+yr1_yrMoTime = yr1(iu);
+skillOut.dateTime(1:length(yr1_yrMoTime),1) = yr1_yrMoTime;
+ 
 
 % original skillOut.dateTime(:,1)=resOut.yrMoTime(1):day(1):resOut.yrMoTime(1)+calmonths(12)-day(1);
 


### PR DESCRIPTION
This change modifies a couple lines in HTF_skill that commonly error due to array size mismatches.

I tested some quasi-random stations and time periods, and the results are as follows:

1. For station 8720218 for 20030301-20230228, this yields the same result as the Main branch.
2. For station 9449880 for 20030501-20230430 this yields the same result as the Main branch.
3. For station 8631044 for 20061101-20241031 the Main branch errors in HTF_skill but this yields a result (BSS at 1 month lead = 0.06)
4. For station 8467150 for 20000101-20221231 the Main branch errors in HTF_skill but this yields a result (BSS at 1 month lead = 0.04)
5. For station 9444900 for 19830101-20011231 the Main branch errors in HTF_skill but this yields a result (BSS at 1 month lead = 0.16)

These tests indicate that this change yields the same result as the operational version when that version works, but avoids the error in HTF_skill that happens in the operational version, and thus would be an improvement.